### PR TITLE
Fix missing private keyword in lf_controller

### DIFF
--- a/include/linear_feedback_controller/lf_controller.hpp
+++ b/include/linear_feedback_controller/lf_controller.hpp
@@ -11,6 +11,8 @@ class LFController {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 
+  static constexpr int kNbFreeFlyerDof = 6;
+
   LFController();
   virtual ~LFController();
 
@@ -35,8 +37,6 @@ private:
 
   Eigen::VectorXd control_;
   RobotModelBuilder::SharedPtr rmb_;
-
-  static constexpr int kNbFreeFlyerDof = 6;
 };
 
 }  // namespace linear_feedback_controller

--- a/include/linear_feedback_controller/lf_controller.hpp
+++ b/include/linear_feedback_controller/lf_controller.hpp
@@ -22,7 +22,7 @@ class LFController {
       const linear_feedback_controller_msgs::Eigen::Sensor& sensor_msg,
       const linear_feedback_controller_msgs::Eigen::Control& control_msg);
 
-private:
+ private:
   Eigen::VectorXd desired_configuration_;
   Eigen::VectorXd desired_velocity_;
   Eigen::VectorXd measured_configuration_;

--- a/include/linear_feedback_controller/lf_controller.hpp
+++ b/include/linear_feedback_controller/lf_controller.hpp
@@ -20,6 +20,7 @@ class LFController {
       const linear_feedback_controller_msgs::Eigen::Sensor& sensor_msg,
       const linear_feedback_controller_msgs::Eigen::Control& control_msg);
 
+private:
   Eigen::VectorXd desired_configuration_;
   Eigen::VectorXd desired_velocity_;
   Eigen::VectorXd measured_configuration_;


### PR DESCRIPTION
Attributes named with trailing underscore were not private.
This PR aims at fixing that.