### PR TITLE
Fix the 'first time compilation' error due to the markdown generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ sec_generate_parameter_library(
 add_dependencies(${PROJECT_NAME}_parameters ${PROJECT_NAME}_parameters_doc)
 # Joint estimator params
 sec_generate_parameter_library_markdown(joint_state_estimator_parameters_doc
-                                        src/linear_feedback_controller.yaml)
+                                        src/joint_state_estimator.yaml)
 sec_generate_parameter_library(
   joint_state_estimator_generated_parameters # Lib name
   joint_state_estimator_parameters # CMake target name for the parameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,10 @@ pluginlib_export_plugin_description_file(controller_interface
 #
 # Installation
 #
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc
-        DESTINATION share/${PROJECT_NAME})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/linear_feedback_controller.md
+              ${CMAKE_CURRENT_BINARY_DIR}/joint_state_estimator.md
+        DESTINATION share/${PROJECT_NAME}/doc)
+
 install(
   PROGRAMS tests/pd_plus_controller.py
   DESTINATION lib/${PROJECT_NAME}

--- a/cmake/sec_generate_parameter_library.cmake
+++ b/cmake/sec_generate_parameter_library.cmake
@@ -111,7 +111,7 @@ function(sec_generate_parameter_library_markdown TARGET_NAME YAML_FILE)
 
   # Set the output parameter header file name
   get_filename_component(MARKDOWN_FILE ${YAML_FILE} NAME_WE)
-  set(MARKDOWN_FILE ${CMAKE_CURRENT_BINARY_DIR}/doc/${MARKDOWN_FILE}.md)
+  set(MARKDOWN_FILE ${CMAKE_CURRENT_BINARY_DIR}/${MARKDOWN_FILE}.md)
 
   # Generate the header for the library
   add_custom_target(


### PR DESCRIPTION
This aims at fixing a compilation error appearing when compiling for the first time:
```sh
   Traceback (most recent call last):
    File "/opt/ros/humble/bin/generate_parameter_library_markdown", line 33, in <module>
      sys.exit(load_entry_point('generate-parameter-library-py==0.3.8', 'console_scripts', 'generate_parameter_library_markdown')())
    File "/opt/ros/humble/lib/python3.10/site-packages/generate_parameter_library_py/generate_markdown.py", line 284, in main
      run(args.input_yaml_file, args.output_markdown_file, args.language)
    File "/opt/ros/humble/lib/python3.10/site-packages/generate_parameter_library_py/generate_markdown.py", line 266, in run
      os.makedirs(output_dir)
    File "/usr/lib/python3.10/os.py", line 225, in makedirs
      mkdir(name, mode)
  FileExistsError: [Errno 17] File exists: '/home/runner/work/linear-feedback-controller/linear-feedback-controller/ros_ws/build/linear_feedback_controller/doc'
```

It's a temporary fix, and may need further investigation, yet it fixes some problems encountered with the CI.