### PR TITLE
Disable all non-nominal tests of the PD controller

### DIFF
--- a/tests/test_pd_controller.cpp
+++ b/tests/test_pd_controller.cpp
@@ -17,14 +17,14 @@ TEST(PdControllerTest, Ctor) {
   EXPECT_NO_THROW({ const auto pd_ctrl = PDController(); });
 }
 
-TEST(PdControllerTest, SetGainsEmpty) {
+TEST(PdControllerTest, DISABLED_SetGainsEmpty) {
   auto pd_ctrl = PDController();
 
   EXPECT_ANY_THROW(
       { pd_ctrl.set_gains(Eigen::VectorXd{}, Eigen::VectorXd{}); });
 }
 
-TEST(PdControllerTest, SetGainsWithSpecialDouble) {
+TEST(PdControllerTest, DISABLED_SetGainsWithSpecialDouble) {
   auto pd_ctrl = PDController();
 
   constexpr auto size = 3u;
@@ -53,7 +53,7 @@ TEST(PdControllerTest, SetGainsWithSpecialDouble) {
   }
 }
 
-TEST(PdControllerTest, SetGainsWithDifferentSizes) {
+TEST(PdControllerTest, DISABLED_SetGainsWithDifferentSizes) {
   auto pd_ctrl = PDController();
 
   for (auto &&requested_gains :
@@ -90,7 +90,7 @@ TEST(PdControllerTest, SetGains) {
   }
 }
 
-TEST(PdControllerTest, SetReferencesWithSpecialDouble) {
+TEST(PdControllerTest, DISABLED_SetReferencesWithSpecialDouble) {
   auto pd_ctrl = PDController();
 
   constexpr auto size = 3u;
@@ -120,7 +120,7 @@ TEST(PdControllerTest, SetReferencesWithSpecialDouble) {
   }
 }
 
-TEST(PdControllerTest, SetReferencesWithDifferentSizes) {
+TEST(PdControllerTest, DISABLED_SetReferencesWithDifferentSizes) {
   auto pd_ctrl = PDController();
 
   for (auto &&requested_references :


### PR DESCRIPTION
In order to match with what has been done in lf_controller and linear_feedback_controller tests, this disable the non nominal tests.

Disabled tests can be run with `--gtest_also_run_disabled_tests` and will appears as 'skipped' with a warning when running tests.