### PR TITLE
bugfix: Fix rosdep on alum

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,7 @@
   <depend>linear_feedback_controller_msgs</depend>
   <depend>pal_statistics</depend>
   <depend>generate_parameter_library</depend>
-  <depend>rosidl_dynamic_typesupport</depend>
+  <depend condition="$ROS_DISTRO != humble">rosidl_dynamic_typesupport</depend>
 
   <test_depend>example-robot-data</test_depend>
   <test_depend>gtest</test_depend>


### PR DESCRIPTION
Alum is the OS of PAL which is a frozen ubuntu 22.04 with ROS humble installed.
Though in this distribution they provide ros2_control with the jazzy version.
Hence we need to remove the dependency to `rosidl_dynamic_typesupport` in case we are using rosdep on alum.

Hence I removed the `rosidl_dynamic_typesupport` dependencies if humble is detected.