### PR TITLE
Fix the std::length_error exception thrown by generate_parameter_lib

### DIFF
--- a/src/linear_feedback_controller.yaml
+++ b/src/linear_feedback_controller.yaml
@@ -19,8 +19,7 @@ linear_feedback_controller:
     default_value: 0.9,
     description: "Specifies the filter coefficient for the sensor's exponential filter. If equal to 1 the filter is inactive. I equal to zero the filter crash the signal into a constant being the initial value of the signal.",
     validation: {
-      gt_eq<>: 0.0,
-      lt_eq<>: 1.0,
+      bounds<>: [0.0, 1.0]
     }
   }
   moving_joint_names: {


### PR DESCRIPTION
From #86

Using both `lt/lt_eq` and `gt/gt_eq` doesn't work with the generate_parameter_library since it generates a code that creates a [ParameterDescriptor](https://docs.ros2.org/latest/api/rcl_interfaces/msg/ParameterDescriptor.html) that resizes the `floating_point_range` to size 2, which is not possible (range is expected to be of size 0 or 1).

To fix this, we have to use `bounds<> [min, max]` when doing bounds checking.

This should be merged in all versions (jazzy/humble/...) as fix.