### PR TITLE
Fixed size of feedback gain matrix to handle free-flyer joints

### DIFF
--- a/src/linear_feedback_controller_ros.cpp
+++ b/src/linear_feedback_controller_ros.cpp
@@ -536,9 +536,9 @@ bool LinearFeedbackControllerRos::allocate_memory() {
   input_sensor_msg_.joint_state.effort.resize(joint_nv, 0.0);
 
   input_control_.initial_state = input_sensor_;
-  
+
   /**
-   * Number of rows in the feedback gain matrix: 
+   * Number of rows in the feedback gain matrix:
    *  - equals `nv` if the robot has no free-flyer joint
    *  - equals `nv-6` if the robot has a free-flyer joint
    */

--- a/src/linear_feedback_controller_ros.cpp
+++ b/src/linear_feedback_controller_ros.cpp
@@ -536,7 +536,13 @@ bool LinearFeedbackControllerRos::allocate_memory() {
   input_sensor_msg_.joint_state.effort.resize(joint_nv, 0.0);
 
   input_control_.initial_state = input_sensor_;
-  input_control_.feedback_gain = Eigen::MatrixXd::Zero(nv, 2 * nv);
+  
+  /**
+   * Number of rows in the feedback gain matrix: 
+   *  - equals `nv` if the robot has no free-flyer joint
+   *  - equals `nv-6` if the robot has a free-flyer joint
+   */
+  input_control_.feedback_gain = Eigen::MatrixXd::Zero(joint_nv, 2 * nv);
   input_control_.feedback_gain.fill(
       std::numeric_limits<double>::signaling_NaN());
   input_control_.feedforward = Eigen::VectorXd::Zero(nv);


### PR DESCRIPTION
Previously, the code did not  account for the presence of a free-flyer joint when determining the number of rows in the feedback gain matrix. 