### PR TITLE
add missing include for std::cerr

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782042109,
-        "narHash": "sha256-oDCl/rcvJVTcf6G2ag3YdZSMHDVBBmoXTysY5yzq+Dk=",
+        "lastModified": 1784949360,
+        "narHash": "sha256-eCqieedePi8Yz3aWpO5L0np9zaWrrNEnaqee6tlvjvk=",
         "owner": "gepetto",
         "repo": "flakoboros",
-        "rev": "fc7d44063fa05f1a78c97c63b124c1da2862331c",
+        "rev": "e67524544402534e5ad9b5fb5c6a93a35d72c8c7",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1782566589,
-        "narHash": "sha256-vXVLP31bnnk8KUBUV88Ms2R6P06wdQPZzsXgR6iZ5FI=",
+        "lastModified": 1784985096,
+        "narHash": "sha256-3VYVcSUZEgt/d8yBevh2M6VAp9AYGG1Y0Bz6QSxXpuY=",
         "owner": "gepetto",
         "repo": "gazebros2nix",
-        "rev": "6e51068e9e9fec8e960f68911127ad64b417bf6b",
+        "rev": "73e304338bfb5ac9f27541d9be607b9fa5c9ab2e",
         "type": "github"
       },
       "original": {
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783001154,
-        "narHash": "sha256-kPrfWL8YePlBRv0Sz2J4Uwn6C/HlhM3WZG96Y6TEqeU=",
+        "lastModified": 1785258010,
+        "narHash": "sha256-7vnGa9WX54TurEIWR2BhZf42uFqqZXxjgkgQFnuXqPI=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "7a2bf9834c160a05872d0f77eeadc9362cb6f014",
+        "rev": "d2f9078d29e7d1f9eaa6d6c00065c43e558a1e37",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "rosdistro": "rosdistro"
       },
       "locked": {
-        "lastModified": 1781900693,
-        "narHash": "sha256-4KFk+S9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs=",
+        "lastModified": 1784411287,
+        "narHash": "sha256-oQnBcy+usVzedG8/dsbScEAAKyMJ0nLQHizKfDC1jdU=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "fb296510db68c2e760980ab8c6daf6ded9060213",
+        "rev": "f092cd397fd167ae95ed7e0771f35ae88e519339",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -324,11 +324,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782093830,
-        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
+        "lastModified": 1784580899,
+        "narHash": "sha256-65qjoshs2FUkt+3NzaVutCWjydUpiHElXLo+0SGuvPk=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
+        "rev": "5c4cc964cfb1e3cab9134dabe2d86bc4858f3867",
         "type": "github"
       },
       "original": {
@@ -408,11 +408,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782089418,
-        "narHash": "sha256-LRD1SuQWr49fGq3A+8GLXfsLE2xqIpQA440YDZwms3M=",
+        "lastModified": 1784591072,
+        "narHash": "sha256-zP/WaDxrRu8GANZM61+V2LT/7ycEEdoyLWn7M6WzU7M=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "43f0b40edd0a74c63f66b7b48d969ae6b740d611",
+        "rev": "e3b599ca2e7fcf93d4edf65d7f19bbf6491724f3",
         "type": "github"
       },
       "original": {
@@ -429,11 +429,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1781238695,
-        "narHash": "sha256-Sk8KQa9ryFrkdGGZ64sNdqoVqiGmC+IAAi3qzE7zn8s=",
+        "lastModified": 1784293198,
+        "narHash": "sha256-PYYpx0kwwNGlzRKZW28XfwU7S/J9S3yDp9acpDILhIA=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "a0e7ccc6f866a081acc0656d9cd03cda7acc6853",
+        "rev": "c8b19e9ae58b9eee6eedbd305720825646102334",
         "type": "github"
       },
       "original": {
@@ -452,11 +452,11 @@
         "userborn": "userborn"
       },
       "locked": {
-        "lastModified": 1778508009,
-        "narHash": "sha256-mp63mt+EwfKiVZX+4BC/59g5oTbsXNtSYESVci3opso=",
+        "lastModified": 1784579760,
+        "narHash": "sha256-7YKNfK0RQbUoYkjDI/EpTk76nDUiONJYuOxZnflx7tI=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "dc1baae12eed1758755e73f8aff7fca5502c6e9f",
+        "rev": "48d47346e0c6ad05b6c869ea92649c47723d1cfc",
         "type": "github"
       },
       "original": {
@@ -505,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781810314,
-        "narHash": "sha256-PQfvfKWaBvCysdHFUO5GewwvwIqI/WL6OcrJhDSUdbc=",
+        "lastModified": 1784582828,
+        "narHash": "sha256-uPeuFNSYO429IEiud3iJKWIpN/xrH2CANj1uYNiDxqc=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "14aa44100859a44144878fe079f8089d3fa4dc4e",
+        "rev": "49dac8d206c42175b069b7c6050ba27060a21106",
         "type": "github"
       },
       "original": {

--- a/src/linear_feedback_controller.cpp
+++ b/src/linear_feedback_controller.cpp
@@ -1,5 +1,7 @@
 #include "linear_feedback_controller/linear_feedback_controller.hpp"
 
+#include <iostream>
+
 namespace linear_feedback_controller {
 
 LinearFeedbackController::LinearFeedbackController() {


### PR DESCRIPTION
fix in ros buildfarm:
```cpp
[ 64%] Building CXX object CMakeFiles/linear_feedback_controller.dir/src/linear_feedback_controller.cpp.o
/usr/lib/ccache/c++ -DBOOST_FUSION_INVOKE_MAX_ARITY=12 -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS -DBOOST_MPL_LIMIT_LIST_SIZE=30 -DBOOST_MPL_LIMIT_VECTOR_SIZE=30 -DCOAL_HAS_OCTOMAP -DCOAL_HAVE_OCTOMAP -DCONTROLLER_INTERFACE_MAJOR_VERSION=6 -DCONTROLLER_INTERFACE_MINOR_VERSION=8 -DCONTROLLER_INTERFACE_PATCH_VERSION=0 -DDEFAULT_RMW_IMPLEMENTATION=rmw_fastrtps_cpp -DFASTCDR_DYN_LINK -DFMT_SHARED -DLINEAR_FEEDBACK_CONTROLLER_DO_EXPORT -DLINEAR_FEEDBACK_CONTROLLER_IS_SHARED -DOCTOMAP_MAJOR_VERSION=1 -DOCTOMAP_MINOR_VERSION=10 -DOCTOMAP_PATCH_VERSION=0 -DPINOCCHIO_ENABLE_TEMPLATE_INSTANTIATION -DPINOCCHIO_URDFDOM_HEADERS_MAJOR_VERSION=3 -DPINOCCHIO_URDFDOM_HEADERS_MINOR_VERSION=0 -DPINOCCHIO_URDFDOM_HEADERS_PATCH_VERSION=0 -DPINOCCHIO_WITH_COLLISION -DPINOCCHIO_WITH_HPP_FCL -DPINOCCHIO_WITH_URDFDOM -DROS_PACKAGE_NAME=\"linear_feedback_controller\" -DTINYXML2_IMPORT -D_FILE_OFFSET_BITS=64 -D__STDC_WANT_LIB_EXT1__=1 -Dlinear_feedback_controller_EXPORTS -I/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3/.obj-x86_64-linux-gnu -I/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3/.obj-x86_64-linux-gnu/include -I/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3/include -isystem /opt/ros/rolling/include -isystem /opt/ros/rolling/include/pal_statistics_msgs -isystem /opt/ros/rolling/include/rclcpp -isystem /opt/ros/rolling/include/rclcpp_lifecycle -isystem /opt/ros/rolling/include/pal_statistics -isystem /opt/ros/rolling/include/rcl -isystem /opt/ros/rolling/include/rcl_interfaces -isystem /opt/ros/rolling/include/builtin_interfaces -isystem /opt/ros/rolling/include/rosidl_runtime_c -isystem /opt/ros/rolling/include/rcutils -isystem /opt/ros/rolling/include/rosidl_buffer -isystem /opt/ros/rolling/include/rosidl_typesupport_interface -isystem /opt/ros/rolling/include/service_msgs -isystem /opt/ros/rolling/includefastcdr -isystem /opt/ros/rolling/include/rosidl_runtime_cpp -isystem /opt/ros/rolling/include/rosidl_typesupport_fastrtps_cpp -isystem /opt/ros/rolling/include/rosidl_buffer_backend -isystem /opt/ros/rolling/include/rmw -isystem /opt/ros/rolling/include/rosidl_dynamic_typesupport -isystem /opt/ros/rolling/include/rosidl_typesupport_fastrtps_c -isystem /opt/ros/rolling/include/rosidl_typesupport_introspection_c -isystem /opt/ros/rolling/include/rosidl_typesupport_introspection_cpp -isystem /opt/ros/rolling/include/rcl_logging_interface -isystem /opt/ros/rolling/include/rcl_yaml_param_parser -isystem /opt/ros/rolling/include/type_description_interfaces -isystem /opt/ros/rolling/include/libstatistics_collector -isystem /opt/ros/rolling/include/rcpputils -isystem /opt/ros/rolling/include/statistics_msgs -isystem /opt/ros/rolling/include/rosgraph_msgs -isystem /opt/ros/rolling/include/rosidl_typesupport_cpp -isystem /opt/ros/rolling/include/rosidl_typesupport_c -isystem /opt/ros/rolling/include/tracetools -isystem /opt/ros/rolling/include/lifecycle_msgs -isystem /opt/ros/rolling/include/rcl_lifecycle -isystem /opt/ros/rolling/include/controller_interface -isystem /opt/ros/rolling/include/hardware_interface -isystem /opt/ros/rolling/include/pluginlib -isystem /opt/ros/rolling/include/ament_index_cpp -isystem /opt/ros/rolling/include/class_loader -isystem /opt/ros/rolling/include/urdf -isystem /opt/ros/rolling/include/urdfdom -isystem /opt/ros/rolling/include/urdfdom_headers -isystem /opt/ros/rolling/include/realtime_tools -isystem /opt/ros/rolling/include/rclcpp_action -isystem /opt/ros/rolling/include/action_msgs -isystem /opt/ros/rolling/include/unique_identifier_msgs -isystem /opt/ros/rolling/include/rcl_action -isystem /opt/ros/rolling/include/joint_limits -isystem /opt/ros/rolling/include/trajectory_msgs -isystem /opt/ros/rolling/include/geometry_msgs -isystem /opt/ros/rolling/include/std_msgs -isystem /opt/ros/rolling/include/control_msgs -isystem /opt/ros/rolling/include/diagnostic_msgs -isystem /opt/ros/rolling/include/sensor_msgs -isystem /opt/ros/rolling/include/control_toolbox -isystem /opt/ros/rolling/include/rsl -isystem /usr/include/eigen3 -isystem /usr/share -isystem /opt/ros/rolling/include/filters -isystem /opt/ros/rolling/include/tf2_geometry_msgs -isystem /opt/ros/rolling/include/tf2 -isystem /opt/ros/rolling/include/tf2_ros -isystem /opt/ros/rolling/include/message_filters -isystem /opt/ros/rolling/include/tf2_msgs -isystem /opt/ros/rolling/include/nav_msgs -isystem /opt/ros/rolling/include/linear_feedback_controller_msgs -isystem /opt/ros/rolling/include/tf2_eigen -isystem /opt/ros/rolling/include/pinocchio/deprecated -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion -g -O2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -ffile-prefix-map=/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3=. -flto=auto -ffat-lto-objects -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fdebug-prefix-map=/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3=/usr/src/ros-rolling-linear-feedback-controller-4.0.3-1resolute.20260728.200827 -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=3 -std=gnu++20 -fPIC -fvisibility=hidden -MD -MT CMakeFiles/linear_feedback_controller.dir/src/linear_feedback_controller.cpp.o -MF CMakeFiles/linear_feedback_controller.dir/src/linear_feedback_controller.cpp.o.d -o CMakeFiles/linear_feedback_controller.dir/src/linear_feedback_controller.cpp.o -c /tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3/src/linear_feedback_controller.cpp
/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3/src/linear_feedback_controller.cpp: In member function ‘bool linear_feedback_controller::LinearFeedbackController::set_initial_state(const Eigen::VectorXd&, const Eigen::VectorXd&)’:
/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3/src/linear_feedback_controller.cpp:53:10: error: ‘cerr’ is not a member of ‘std’
   53 |     std::cerr << ss.str() << std::endl;
      |          ^~~~
/tmp/binarydeb/ros-rolling-linear-feedback-controller-4.0.3/src/linear_feedback_controller.cpp:2:1: note: ‘std::cerr’ is defined in header ‘<iostream>’; this is probably fixable by adding ‘#include <iostream>’
    1 | #include "linear_feedback_controller/linear_feedback_controller.hpp"
  +++ |+#include <iostream>
    2 |
```